### PR TITLE
Provide a more instructive warning when ghc-mod is not installed

### DIFF
--- a/lib/util-ghc-mod.coffee
+++ b/lib/util-ghc-mod.coffee
@@ -104,7 +104,7 @@ type = ({onResult, onComplete, fileName, pt}) ->
       else if line == "execvp(): No such file or directory"
         console.warn "#{atom.config.get('ide-haskell.ghcModPath')} not be found. please run 'cabal install ghc-mod'"
       else
-        console.warn "!!! got something strange from ghc-mod type:", [line]
+        console.warn "got something strange from ghc-mod type:", [line]
       resultViewed = true
     onComplete: ->
       onComplete()


### PR DESCRIPTION
When I first installed your Atom package, I didn't quite read the instructions and got an obscure error message. Eventually I figured out that I didn't have ghc-mod installed.

I added check to see if the command failed because the executable was not found. I haven't worked with coffeescript before, so if you have suggestions on how to this differently, I'm happy to update the code and resubmit.
