### PR TITLE
Don't use deprecated screenPositionFromMouseEvent

### DIFF
--- a/lib/editor-control.coffee
+++ b/lib/editor-control.coffee
@@ -115,7 +115,7 @@ class EditorControl
   showExpressionType: (e) ->
     return unless isHaskellSource(@editor.getUri()) and not @exprTypeTooltip?
 
-    screenPt = @editorView.screenPositionFromMouseEvent(e)
+    screenPt = @editor.screenPositionForPixelPosition({top: e.screenY, left: e.screenX})
     bufferPt = @editor.bufferPositionForScreenPosition(screenPt)
     if screenPt.isEqual bufferPt
 


### PR DESCRIPTION
Relating to [this discussion](https://discuss.atom.io/t/editorview-screenpositionfrommouseevent-is-deprecated-how-fix-dependant-packages/11790/2), this change removes the deprecated (and since removed) method usage and uses a different method.
