### PR TITLE
Fixing a missing resize cursor on Windows.

### DIFF
--- a/styles/ide-haskell.less
+++ b/styles/ide-haskell.less
@@ -164,3 +164,13 @@ atom-text-editor::shadow {
     white-space: pre-wrap !important;
   }
 }
+
+.platform-win32 {
+
+  .ide-haskell-panel {
+
+    .resize-handle {
+      cursor: ns-resize;
+    }
+  }
+}


### PR DESCRIPTION
The bug is similar to https://github.com/atom/tree-view/pull/148.

This commit overrides the resize cursor for the panel when on Windows.