### PR TITLE
Allowing text selection in bottom pane

### DIFF
--- a/lib/output-view.coffee
+++ b/lib/output-view.coffee
@@ -8,7 +8,7 @@ class OutputView extends View
   switchCounter: 0   # if counter is 0 the error tab is switched
 
   @content: ->
-    @div class: 'ide-haskell-panel', =>
+    @div class: 'ide-haskell-panel native-key-bindings', tabindex: -1, =>
       @div outlet: 'resizeHandle', class: 'resize-handle'
       @div class: 'panel', =>
         @div class: 'panel-heading', =>


### PR DESCRIPTION
This patch makes it possible to copy text from the bottom pane, which happens to be useful at times.

Copying solution from:
https://github.com/tcarlsen/atom-message-panel/issues/24#issuecomment-46189386