### PR TITLE
Prettifier runs in file's directory

### DIFF
--- a/lib/plugin-manager.coffee
+++ b/lib/plugin-manager.coffee
@@ -3,6 +3,7 @@
 utilStylishHaskell = require './util-stylish-haskell'
 utilCabalFormat = require './util-cabal-format'
 {CompositeDisposable, Emitter} = require 'atom'
+path = require 'path'
 
 class PluginManager
 
@@ -81,7 +82,7 @@ class PluginManager
       when 'haskell' then utilStylishHaskell
       when 'cabal' then utilCabalFormat
       else throw new Error "Unknown format #{format}"
-    util.prettify editor.getText(),
+    util.prettify editor.getText(), path.dirname(editor.getPath()),
       onComplete: (text) ->
         editor.setText(text)
         if editor.getLastCursor()?

--- a/lib/plugin-manager.coffee
+++ b/lib/plugin-manager.coffee
@@ -4,6 +4,7 @@ utilStylishHaskell = require './util-stylish-haskell'
 utilCabalFormat = require './util-cabal-format'
 {CompositeDisposable, Emitter} = require 'atom'
 path = require 'path'
+fs = require 'fs'
 
 class PluginManager
 
@@ -82,7 +83,13 @@ class PluginManager
       when 'haskell' then utilStylishHaskell
       when 'cabal' then utilCabalFormat
       else throw new Error "Unknown format #{format}"
-    util.prettify editor.getText(), path.dirname(editor.getPath()),
+    try
+      workDir = path.dirname(editor.getPath())
+      if not fs.statSync(workDir).isDirectory()
+        workDir = '.'
+    catch
+      workDir = '.'
+    util.prettify editor.getText(), workDir,
       onComplete: (text) ->
         editor.setText(text)
         if editor.getLastCursor()?

--- a/lib/util-cabal-format.coffee
+++ b/lib/util-cabal-format.coffee
@@ -16,13 +16,15 @@ withTempFile = (contents, callback) ->
         FS.close info.fd, -> FS.unlink info.path
 
 # run cabal format
-prettify = (text, {onComplete, onFailure}) ->
+prettify = (text, workingDirectory, {onComplete, onFailure}) ->
   shpath = atom.config.get('ide-haskell.cabalPath')
 
   withTempFile text, (path, close) ->
     proc = new BufferedProcess
       command: shpath
       args: ['format', path]
+      options:
+        cwd: workingDirectory
       exit: ->
         FS.readFile path, encoding: 'utf-8', (error, text) ->
           if error?

--- a/lib/util-stylish-haskell.coffee
+++ b/lib/util-stylish-haskell.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 
 # run stylish-haskell backend
-prettify = (text, {onComplete, onFailure}) ->
+prettify = (text, workingDirectory, {onComplete, onFailure}) ->
 
   lines = []
 
@@ -12,6 +12,8 @@ prettify = (text, {onComplete, onFailure}) ->
   proc = new BufferedProcess
     command: shpath
     args: []
+    options:
+      cwd: workingDirectory
     stdout: (line) ->
       lines.push(line)
     exit: -> onComplete?(lines.join(''))


### PR DESCRIPTION
This change is primarily for stylish-haskell, which searches
for `.stylish-haskell.yaml` configuration file from current working
directory up to the root. This makes possible to have better controll
of haskell source formatting.