### PR TITLE
"panel" instead of "output" in settings text

### DIFF
--- a/lib/ide-haskell.coffee
+++ b/lib/ide-haskell.coffee
@@ -77,7 +77,7 @@ module.exports = IdeHaskell =
     hotkeyToggleOutput:
       type: "string"
       default: ''
-      description: 'Hotkey to toggle output'
+      description: 'Hotkey to toggle panel'
     hotkeyShutdownBackend:
       type: "string"
       default: ''


### PR DESCRIPTION
This is more clear and is more consistent with the wording in the menu