### PR TITLE
Reduce CPU used by progress bar, fixes #123

### DIFF
--- a/lib/output-panel/views/progress-bar.coffee
+++ b/lib/output-panel/views/progress-bar.coffee
@@ -6,8 +6,13 @@ class ProgressBar extends HTMLElement
     @span.style.setProperty 'width', "#{progress * 100}%"
     if progress <= 0
       @style.setProperty 'visibility', 'hidden'
+      # we remove the enabled class to avoid the expensive animation styles
+      # associated with this element. See issue #123
+      @span.classList.remove 'enabled';
     else
       @style.setProperty 'visibility', 'visible'
+      # enable the aforementioned styles
+      @span.classList.add 'enabled';
 
 
 ProgressBarElement =

--- a/styles/ide-haskell.less
+++ b/styles/ide-haskell.less
@@ -212,7 +212,7 @@ ide-haskell-panel {
     border-radius: 3px;
     position: relative;
     margin-left: 1em;
-    &>span {
+    &>span.enabled {
       display: block;
       background-color: @background-color-info;
       position: absolute;


### PR DESCRIPTION
Even when the build progress bar is not visible it frequently causes
style recalculation events, constantly waking the CPU up. Instead, we
disable the styles when the progress bar is not active.

I wrote the simplest fix that will work.  It might be cleaner to actually remove the ide-haskell-progress-bar element when it isn't needed rather than hide it with CSS.