### PR TITLE
Panel auto hide option, for when there is nothing to show

### DIFF
--- a/lib/ide-haskell.coffee
+++ b/lib/ide-haskell.coffee
@@ -53,6 +53,11 @@ module.exports = IdeHaskell =
       '''
       enum: ['bottom', 'left', 'top', 'right']
 
+    panelAutoHide:
+      type: "boolean"
+      default: false
+      description: "Hide panel when there are no messages to show"
+
   cleanConfig: ->
     [ 'onSaveCheck'
     , 'onSaveLint'

--- a/lib/output-panel/output-panel.coffee
+++ b/lib/output-panel/output-panel.coffee
@@ -28,6 +28,12 @@ class OutputPanel
     else
       @panel.show()
 
+  hide: ->
+    @panel.hide()
+
+  show: ->
+    @panel.show()
+
   destroy: ->
     @disposables.dispose()
     @panel.destroy()

--- a/lib/plugin-manager.coffee
+++ b/lib/plugin-manager.coffee
@@ -14,7 +14,9 @@ class PluginManager
     @controllers = new WeakMap
     @disposables.add @emitter = new Emitter
 
-    @disposables.add @onResultsUpdated ({types}) => @updateEditorsWithResults(types)
+    @disposables.add @onResultsUpdated ({types}) =>
+      @panelAutoHide() if atom.config.get('ide-haskell.panelAutoHide')
+      @updateEditorsWithResults(types)
 
     @createOutputViewPanel(state)
     @subscribeEditorController()
@@ -55,6 +57,12 @@ class PluginManager
 
   onResultsUpdated: (callback) =>
     @checkResults.onDidUpdate callback
+
+  panelAutoHide: ->
+    if @checkResults.results.length > 0
+      @outputView?.show()
+    else
+      @outputView?.hide()
 
   controller: (editor) ->
     @controllers?.get? editor


### PR DESCRIPTION
Adds a config option:

<img width="322" alt="screenshot 2017-01-15 12 04 37" src="https://cloud.githubusercontent.com/assets/102781/21962316/cb83979a-db1a-11e6-9091-93c8290236a0.png">

Which behaves like so:

![auto-hide-hkide](https://cloud.githubusercontent.com/assets/102781/21962319/daaab9f6-db1a-11e6-9e99-b9fa08e35196.gif)

Didn't presume to make it `default: true` as I'm unsure if this is a generally desired behavior, but I prefer to have the visual space when there are no errors, perhaps someone else would too? 😄