### PR TITLE
Avoid dobule Prettifier unnormal exit message

### DIFF
--- a/src/prettify/util-run-filter.ts
+++ b/src/prettify/util-run-filter.ts
@@ -21,7 +21,11 @@ export async function runFilter ({command, args, cwd, stdin}: IRunFilterArgs) {
         if (!error) {
           resolve(stdout)
         } else {
-          reject(error)
+          if (stderr.length > 0) {
+              reject()
+          } else {
+              reject(error)
+          }
         }
       })
       if (stdin) {


### PR DESCRIPTION
Since already notify user by "Prettifier problems" and show the full "stderr"
Advice not notify again in the "Fail to prettify" if the "stderr" not empty.

So a silent exit like spawn error can still catch by "Fail to prettify".